### PR TITLE
Added tasks to check HANA is up and happy

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ This project has used the following software version.
 
 We strongly recommend using these or newer versions when deploying.
 
-On SUSE Linux Enterprise Server 15 SP4 or newer, the requirements can be installed
-using the following commands:
+On SUSE Linux Enterprise Server 15 SP4 or newer, the requirements can be
+installed using the following commands:
 
 ```
 # add Python 3 repository

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ We strongly recommend using these or newer versions when deploying.
 On SUSE Linux Enterprise Server 15 SP4 or newer, the requirements can be
 installed using the following commands:
 
-```
+```shell
 # add Python 3 repository
 SUSEConnect -p sle-module-python3/15.4/x86_64
 # Install Python 3.10 and all other requirements

--- a/roles/cluster/tasks/pre-checks.yml
+++ b/roles/cluster/tasks/pre-checks.yml
@@ -1,4 +1,19 @@
 ---
+- name: Include hana sid and instance variables
+  ansible.builtin.include_vars: ../shared/vars/hana-sid-instance-vars.yml
+
+- name: Include hana sid and instance checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hana-sid-instance.yml
+
+- name: Include hdbsql variables
+  ansible.builtin.include_vars: ../shared/vars/hdbsql-vars.yml
+
+- name: Include hdbsql checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hdbsql.yml
+
+- name: Ensure HANA is running
+  ansible.builtin.include_tasks: ../shared/tasks/pre-check-hana-is-running.yml
+
 - name: Assert that required variables are defined
   ansible.builtin.assert:
     that: "{{ item }} is defined"

--- a/roles/hana-system-replication-hooks/tasks/pre-checks.yml
+++ b/roles/hana-system-replication-hooks/tasks/pre-checks.yml
@@ -1,4 +1,19 @@
 ---
+- name: Include hana sid and instance variables
+  ansible.builtin.include_vars: ../shared/vars/hana-sid-instance-vars.yml
+
+- name: Include hana sid and instance checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hana-sid-instance.yml
+
+- name: Include hdbsql variables
+  ansible.builtin.include_vars: ../shared/vars/hdbsql-vars.yml
+
+- name: Include hana sid and instance checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hdbsql.yml
+
+- name: Ensure HANA is running
+  ansible.builtin.include_tasks: ../shared/tasks/pre-check-hana-is-running.yml
+
 - name: Assert that required variables are defined and populated
   ansible.builtin.assert:
     that:
@@ -29,18 +44,6 @@
   ansible.builtin.set_fact:
     int_var_node_is_primary: "{{ hana_system_replication_primary == inventory_hostname }}"
   check_mode: false
-
-- name: Include hana sid and instance variables
-  ansible.builtin.include_vars: ../shared/vars/hana-sid-instance-vars.yml
-
-- name: Include hana sid and instance checks
-  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hana-sid-instance.yml
-
-- name: Include hdbsql variables
-  ansible.builtin.include_vars: ../shared/vars/hdbsql-vars.yml
-
-- name: Include hana sid and instance checks
-  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hdbsql.yml
 
 - name: Gather package facts
   ansible.builtin.package_facts:

--- a/roles/hana-system-replication/tasks/pre-checks.yml
+++ b/roles/hana-system-replication/tasks/pre-checks.yml
@@ -11,6 +11,9 @@
 - name: Include hdbsql checks
   ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hdbsql.yml
 
+- name: Ensure HANA is running
+  ansible.builtin.include_tasks: ../shared/tasks/pre-check-hana-is-running.yml
+
 - name: Gather package facts
   ansible.builtin.package_facts:
   check_mode: false

--- a/roles/hana_backup/tasks/pre-checks.yml
+++ b/roles/hana_backup/tasks/pre-checks.yml
@@ -1,4 +1,19 @@
 ---
+- name: Include hana sid and instance variables
+  ansible.builtin.include_vars: ../shared/vars/hana-sid-instance-vars.yml
+
+- name: Include hana sid and instance checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hana-sid-instance.yml
+
+- name: Include hdbsql variables
+  ansible.builtin.include_vars: ../shared/vars/hdbsql-vars.yml
+
+- name: Include hdbsql checks
+  ansible.builtin.include_tasks: ../shared/tasks/pre-checks-hdbsql.yml
+
+- name: Ensure HANA is running
+  ansible.builtin.include_tasks: ../shared/tasks/pre-check-hana-is-running.yml
+
 - name: Ensure required variables are defined
   ansible.builtin.assert:
     that:
@@ -9,77 +24,7 @@
     success_msg: >-
       The {{ item }} variable is correctly defined.
   loop:
-    - hana_sid
-    - hana_instance_number
     - hana_systemdb_password
-  check_mode: false
-
-- name: Check hana_sid is compliant
-  ansible.builtin.assert:
-    that:
-      hana_sid is ansible.builtin.regex('[A-Z]{1}[A-Z0-9]{2}')
-    fail_msg: >-
-      hana_sid must consist of three characters. Characters must be
-      uppercase alphabetical characters or numbers only.  The first alphabetical
-      character.
-    success_msg: >-
-      hana_sid matches the required pattern.
-  check_mode: false
-
-- name: Ensure that hana_sid is not a reserved SID name
-  ansible.builtin.assert:
-    that:
-      hana_sid not in int_var_reserved_sids
-    fail_msg: >-
-      hana_sid is set to {{ hana_sid }}, this is a reserved SID and cannot be
-      used.  Change the variable hana_sid to an allowed value.
-    success_msg: >-
-      hana_sid is not a reserved value
-  check_mode: false
-
-- name: Ensure that HANA instance number is compliant
-  ansible.builtin.assert:
-    that:
-      hana_instance_number is ansible.builtin.regex('[0-9]{2}')
-    fail_msg: >-
-      hana_instance_number is set to {{ hana_instance_number }}, which is not
-      compliant. hana_instance_number must be a composed of two numerical
-      digits, for example '00'.
-    success_msg: >-
-      hana_instance_number is an allowed value.
-  check_mode: false
-
-- name: Check hdbsql binary data
-  ansible.builtin.stat:
-    path: "{{ int_var_hdbsql_path }}"
-    get_checksum: false
-  register: int_reg_hdbsql_check
-  changed_when: false
-  failed_when: false
-  check_mode: false
-
-- name: Ensure hdbsql binary exists
-  ansible.builtin.assert:
-    that:
-      - not int_reg_hdbsql_check.failed
-      - int_reg_hdbsql_check.stat.exists
-      - int_reg_hdbsql_check.stat.isreg
-    fail_msg: >-
-      The expected file {{ int_var_hdbsql_path }} was not either not found or was not a
-      a regular file. This was not expected. Please report this error.
-    success_msg: >-
-      The file {{ int_var_hdbsql_path }} was found.
-  check_mode: false
-
-- name: Ensure hdbsql binary is executable
-  ansible.builtin.assert:
-    that:
-      - int_reg_hdbsql_check.stat.executable
-    fail_msg: >-
-      The file {{ int_var_hdbsql_path }} was found but it is not executable. It is
-      necessary to add execute permission for the root user.
-    success_msg: >-
-      The file {{ int_var_hdbsql_path }} is executable.
   check_mode: false
 
 # The pre-checks need to run independently of the tasks section, so we need to

--- a/roles/shared/tasks/pre-check-hana-is-running.yml
+++ b/roles/shared/tasks/pre-check-hana-is-running.yml
@@ -1,0 +1,35 @@
+- name: Get HANA status
+  ansible.builtin.shell: >-
+    . ~/.bashrc &&
+    sapcontrol -nr {{ hana_instance_number }} -function GetProcessList
+  become: true
+  become_user: "{{ hana_sid | lower }}adm"
+  register: int_reg_hana_status
+  changed_when: false
+  failed_when: false
+
+# Here we want to store all lines that start '^hdb' in a new fact
+- name: Parse HANA status output
+  ansible.builtin.set_fact:
+    int_fact_hana_status_lines: "{{ int_reg_hana_status.stdout | regex_findall('^hdb.*', multiline=true) }}"
+
+- name: Show me what you got?
+  ansible.builtin.debug:
+    msg: "{{ (item | split(', '))[2] }}"
+  loop: "{{ int_fact_hana_status_lines }}"
+
+- name: Assert all HANA services are correctly started
+  ansible.builtin.assert:
+    that: "{{ (item | split(', '))[2] == 'GREEN' }}"
+    fail_msg: >-
+      The service '{{ (item | split(', '))[0] }}' has a status of
+      '{{ (item | split(', '))[2] }}'', but 'GREEN' was expected. This may be
+      because HANA is not started, is in the process of starting or shutting
+      down or that there is a problem with the installation. Ensure that HANA
+      is fully started before running the role again. Ensure that all services
+      report as 'GREEN' when running the command
+      'sapcontrol -nr {{ hana_instance_number }} -function GetProcessList' as
+      the '{{ hana_sid | lower }}adm' user on the HANA host
+    success_msg: >-
+      The HANA service {{ item }} is started.
+  loop: "{{ int_fact_hana_status_lines }}"


### PR DESCRIPTION
Added a task file in the 'shared' role that checks all hosts in the play for the status of HANA based on the output of `sapcontrol -nr {{ hana_instance_number }} -function GetProcessList`. If any services are not 'GREEN', the assert will fail and provide a meaningful error.

hana_backup, hana_system_replication, hana_system_replication_hooks and cluster now all call this task list as part of their pre-checks.